### PR TITLE
fix: restore per-artifact subdirectories with download-artifact v7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -243,6 +243,7 @@ jobs:
         with:
           path: firmware-artifacts
           pattern: firmware*
+          merge-multiple: false
 
       # Create output directory structure
       - name: Create output directory structure


### PR DESCRIPTION
## Summary

When `download-artifact` was updated from v6 to v7 in commit 4086cb1, the default behavior for pattern-based downloads changed:

- **v6**: Creates subdirectory per artifact (`firmware-artifacts/firmware/...`)
- **v7**: Merges all artifacts directly into path (`firmware-artifacts/...`)

This broke the 'Organize firmware files' step which expects each artifact to be in its own subdirectory.

## The Bug

The firmware folder ends up named after the version number (e.g., `26.3.2.1`) instead of `firmware`, causing 404s:

- ❌ `https://apolloautomation.github.io/MSR-2/firmware/manifest.json` → 404
- ✅ `https://apolloautomation.github.io/MSR-2/26.3.2.1/manifest.json` → works

## The Fix

Adding `merge-multiple: false` restores the v6 behavior where each artifact gets its own subdirectory.

## Affected Repos

Any repo using this shared workflow that hasn't successfully deployed since the Jan 26 dependabot update, including MSR-2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated firmware artifact download configuration in CI/CD workflow to modify how multiple artifacts are processed during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->