### PR TITLE
Harden label-check for pull_request_target callers

### DIFF
--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -5,13 +5,16 @@ jobs:
   label-check:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
       - name: Write PR Body to File
+        # Pass the body through an environment variable instead of
+        # interpolating it into the script, so PR content can never be
+        # executed as shell code. Required for pull_request_target callers,
+        # which run with a write token. The checkout step was removed
+        # because no repository files are used.
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          set +H
-          set +o histexpand
-          printf '%s\n' "${{ github.event.pull_request.body }}" > pr_body.txt
+          printf '%s\n' "$PR_BODY" > pr_body.txt
       - name: Determine Single Label
         id: determine_label
         run: |


### PR DESCRIPTION
Passes the PR body through an environment variable instead of interpolating it into the shell script, closing a script-injection vector, and drops the unused checkout step.

This prepares the reusable workflow to be called from \pull_request_target\ triggers in the device repos. Fork-submitted PRs (like ApolloAutomation/AIR-1#97) currently fail the Label Check because \pull_request\ runs from forks get a read-only token and cannot add labels (\403 Resource not accessible by integration\). The device repos will switch their label-check callers to \pull_request_target\ in follow-up PRs; this PR should merge first since \pull_request_target\ runs with a write token and must not execute PR-controlled content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)