### PR TITLE
Append a correct Full Changelog link to release notes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,7 +91,7 @@ jobs:
 
     outputs:
       version: ${{ steps.read_version.outputs.version }}
-      body: ${{ steps.run-release-drafter.outputs.body }}
+      body: ${{ steps.finalize-notes.outputs.body }}
       html_url: ${{ steps.run-release-drafter.outputs.html_url }}
     
     permissions:
@@ -131,6 +131,29 @@ jobs:
           name: Release ${{ steps.read_version.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Finalize release notes
+        id: finalize-notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DRAFTER_BODY: ${{ steps.run-release-drafter.outputs.body }}
+          VERSION: ${{ steps.read_version.outputs.version }}
+        run: |
+          # Drop any template-generated Full Changelog line: release-drafter cannot
+          # render 4-part versions ($RESOLVED_VERSION is semver-coerced, so old
+          # templates always linked ...X.Y.Z.1). Append a correct compare link here,
+          # where the real tag is known.
+          BODY=$(printf '%s\n' "$DRAFTER_BODY" | sed '/^\*\*Full Changelog\*\*:/d')
+          PREV=$(gh release list --repo "$GITHUB_REPOSITORY" --exclude-drafts --limit 20 --json tagName --jq "[.[].tagName | select(. != \"$VERSION\")][0]")
+          if [ -n "$PREV" ] && [ "$PREV" != "null" ]; then
+            BODY=$(printf '%s\n\n**Full Changelog**: https://github.com/%s/compare/%s...%s' "$BODY" "$GITHUB_REPOSITORY" "$PREV" "$VERSION")
+          fi
+          gh release edit "$VERSION" --repo "$GITHUB_REPOSITORY" --notes "$BODY"
+          {
+            echo 'body<<RELEASE_NOTES_EOF'
+            printf '%s\n' "$BODY"
+            echo 'RELEASE_NOTES_EOF'
+          } >> "$GITHUB_OUTPUT"
 
   prepare-build-matrix:
     name: Prepare Build Matrix


### PR DESCRIPTION
## Problem

Every product repo's `release-drafter.yml` template ends with:

```
**Full Changelog**: https://github.com/ApolloAutomation/<repo>/compare/$PREVIOUS_TAG...$RESOLVED_VERSION.1
```

release-drafter semver-coerces versions, so Apollo's 4-part `YY.M.D.N` versions lose the final part — `$RESOLVED_VERSION` for `26.3.2.5` is `26.3.2`, and the hardcoded `.1` suffix means the link points at `...26.3.2.1` no matter what was released. It's only accidentally correct when the same-day bump count is 1. There is **no drafter template variable for the real tag** ([template variables](https://github.com/release-drafter/release-drafter#template-variables)), so this is unfixable in per-repo config.

## Fix

The workflow itself knows the real tag — it reads it from Core.yaml two steps earlier. This adds a `Finalize release notes` step after the drafter publishes:

1. Strip any template-generated `**Full Changelog**:` line from the body
2. Append a correct one: `compare/<previous release tag>...<real version>`
3. `gh release edit` the published release with the fixed body
4. Pass the fixed body onward as the job's `body` output (it feeds the firmware manifest `summary`, i.e. what users see in Home Assistant)

## Compatibility

- Repos with today's templates: broken line replaced with a correct one — works immediately, no repo changes needed
- Repos that drop the line from their template (PRs open across the product repos for release-notes formatting): link appended
- First release of a repo (no previous tag): line is skipped
- `html_url` output and everything else untouched

Companion formatting PRs (bold headings, no footer, line removed from templates) are open on MTR-1/AIR-1/MSR-1/MSR-2/H-1/R_PRO-1/PLT-1/PUMP-1/BTN-1/TEMP-1/H-2 — but this change is independent and safe to merge before or after them.