### PR TITLE
Add reusable esphome-ci and autoassign workflows

### DIFF
--- a/.github/workflows/autoassign.yml
+++ b/.github/workflows/autoassign.yml
@@ -1,0 +1,28 @@
+name: Auto Assign
+
+on:
+  workflow_call:
+    inputs:
+      assignees:
+        description: 'Comma-separated GitHub usernames to assign'
+        required: true
+        type: string
+      num-of-assignees:
+        description: 'How many assignees to pick from the list'
+        required: false
+        type: number
+        default: 1
+
+jobs:
+  auto-assign:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Auto-assign issue
+        uses: pozil/auto-assign-issue@v4
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          assignees: ${{ inputs.assignees }}
+          numOfAssignee: ${{ inputs.num-of-assignees }}

--- a/.github/workflows/esphome-ci.yml
+++ b/.github/workflows/esphome-ci.yml
@@ -49,6 +49,8 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Build ESPHome firmware to verify configuration
         uses: esphome/build-action@v7
         with:

--- a/.github/workflows/esphome-ci.yml
+++ b/.github/workflows/esphome-ci.yml
@@ -1,0 +1,56 @@
+name: ESPHome CI
+
+on:
+  workflow_call:
+    inputs:
+      yaml-files:
+        description: 'ESPHome YAML file(s) to build (multiline string, one per line)'
+        required: true
+        type: string
+      esphome-versions:
+        description: 'ESPHome versions to build against (multiline string, one per line)'
+        required: false
+        type: string
+        default: |
+          stable
+          beta
+          dev
+
+jobs:
+  prepare-matrix:
+    name: Prepare Build Matrix
+    runs-on: ubuntu-latest
+    outputs:
+      files: ${{ steps.parse.outputs.files }}
+      versions: ${{ steps.parse.outputs.versions }}
+    steps:
+      - name: Parse inputs into JSON arrays
+        id: parse
+        env:
+          YAML_FILES: ${{ inputs.yaml-files }}
+          ESPHOME_VERSIONS: ${{ inputs.esphome-versions }}
+        run: |
+          files=$(printf '%s' "$YAML_FILES" | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          versions=$(printf '%s' "$ESPHOME_VERSIONS" | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          echo "files=$files" >> "$GITHUB_OUTPUT"
+          echo "versions=$versions" >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Building ${{ matrix.file }} / ESPHome ${{ matrix.esphome-version }}
+    needs: prepare-matrix
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        file: ${{ fromJson(needs.prepare-matrix.outputs.files) }}
+        esphome-version: ${{ fromJson(needs.prepare-matrix.outputs.versions) }}
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v6
+      - name: Build ESPHome firmware to verify configuration
+        uses: esphome/build-action@v7
+        with:
+          yaml-file: ${{ matrix.file }}
+          version: ${{ matrix.esphome-version }}


### PR DESCRIPTION
## What

Adds two `workflow_call` workflows consumed by product repos as thin `@main` callers:

- **`esphome-ci.yml`** — inputs `yaml-files` (multiline) and `esphome-versions` (multiline, default stable/beta/dev); builds the cross-product matrix in a prepare job and runs `esphome/build-action` per leg. Also fixes a fleet-wide bug: the inline leaf CI jobs matrix over stable/beta/dev but never pass the version to the build action, so all legs build the default version. This workflow passes `version: ${{ matrix.esphome-version }}`.
- **`autoassign.yml`** — wraps `pozil/auto-assign-issue@v4` with `assignees`/`num-of-assignees` inputs.

## Why

Every product repo currently inlines pinned actions in `ci.yml`/`weekly.yml`/`autoassign.yml` plus daily dependabot, producing one bump PR per repo per action release. After product repos switch to these reusable workflows, all action pins live here only — one grouped dependabot PR updates the whole fleet via `@main`.

Nothing references these files yet; follow-up PRs convert the 17 product repos + ProductTemplate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reusable automated assignment workflow for issues and pull requests.
  * Added a reusable CI workflow to run ESPHome builds across multiple YAML files and version targets.
  * Defaults are provided for common versions, with inputs to customize assignment and build behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->