### PR TITLE
Add persist-credentials: false to all checkout steps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 2
+          persist-credentials: false
 
       - name: Find .yaml Changes in Last PR Merge
         id: check
@@ -103,6 +104,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Read version from YAML file
         id: read_version
@@ -259,6 +262,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       # Download all firmware artifacts
       - name: Download all firmware artifacts

--- a/.github/workflows/minimal-pages.yml
+++ b/.github/workflows/minimal-pages.yml
@@ -23,7 +23,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
-        
+        with:
+          persist-credentials: false
+
       - name: Find and display all symlinks and hardlinks
         run: |
           echo "=== DETAILED LINK ANALYSIS ==="

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Read version from YAML file
         id: read_version
         run: |
@@ -71,6 +73,8 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       
       - name: Debug repository structure
         run: |
@@ -136,7 +140,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
-        
+        with:
+          persist-credentials: false
+
       - name: Debug link analysis
         run: |
           find . -type l -not -path "./.git/*" -ls | tee repo_symlinks.txt


### PR DESCRIPTION
## Summary

Adds `persist-credentials: false` to every `actions/checkout` step in the reusable workflows, matching the hardening already present in `esphome-ci.yml` (added in #27).

By default, `actions/checkout` writes the job's `GITHUB_TOKEN` into the local git config, where any subsequent step (including third-party actions) can read it. None of these jobs push via git — release uploads and API calls use the `GITHUB_TOKEN` env var with `gh`/`curl` — so persisting the credential is unnecessary.

## Changes

- **build.yml** — 3 checkout steps hardened
- **publish.yml** — 3 checkout steps hardened
- **minimal-pages.yml** — 1 checkout step hardened
- **label-check.yml** — no change needed: its checkout step was previously removed entirely (it only reads the PR body and applies labels via API)

## Verification

Ran `actionlint` before and after the change — the finding sets are identical, so no new issues were introduced (the pre-existing shellcheck warnings and the `needs.check-for-yaml` expression warning in build.yml are untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)